### PR TITLE
Fix typos in Init.c and GPIO comments

### DIFF
--- a/Init.c
+++ b/Init.c
@@ -23,7 +23,7 @@ void Sys_init(void)
 {
   //** Flosc clockcontrol by Code Option
   //** Fcpu clock control by Code Option
-  DEGCMD = 0x00;              //** 0xA5 = Enable OCDS module, ohters = Disable OCDS
+  DEGCMD = 0x00;              //** 0xA5 = Enable OCDS module, others = Disable OCDS
   
   P0 = 0x00;
   P0M = 0xFF;

--- a/gpio.c
+++ b/gpio.c
@@ -30,19 +30,19 @@ void GPIO_Init(void)
   // P03 CM0N       | In
   // P04 CM1N       | In
   // P05 CM2N       | In
-  // P06 No use     | OUT L
-  // P07 No use     | OUT L
+  // P06 Not used   | OUT L
+  // P07 Not used   | OUT L
   P0 = (1<<1);  // P01 H (P01 always output)
   P0M = (1<<7)|(1<<6)|(1<<0);
   P0CON = (1<<5)|(1<<4)|(1<<3)|(1<<2);  //P02 P03 P04 P05
   
-  // P10 No use     | Out L
+  // P10 Not used   | Out L
   // P11 IGBTT      | In
   // P12 TOPT       | In
   // P13 SDA        | In
   // P14 SCL        | In
-  // P15 No use     | Out L
-  // P16 No use     | Out L
+  // P15 Not used   | Out L
+  // P16 Not used   | Out L
   P1 = 0;
   P1M = (1<<6)|(1<<5)|(1<<0);
   P1CON = (1<<2)|(1<<1);  //P12 P11


### PR DESCRIPTION
## Summary
- fix misspelling of "others" in `Init.c`
- clarify unused GPIO pins as "Not used" in `gpio.c`

## Testing
- `make -n` *(fails: no Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_684070544e0483238daef5d40c1cd730